### PR TITLE
FEATURE/FIX: Fixed a few broken brushes and enabled erasing of shapes.

### DIFF
--- a/client/store/paintTools.js
+++ b/client/store/paintTools.js
@@ -20,8 +20,8 @@ const initialState = {
   eraseModeOn: false,
   voiceModeOn: false,
   drawModeOn: false,
-  chosenBrush: 'circleLine',
-  chosenBodyPart: 'nose',
+  chosenBrush: 'defaultLine',
+  chosenBodyPart: 'rightHand',
   size: 'small'
 }
 

--- a/client/store/paintTools.js
+++ b/client/store/paintTools.js
@@ -20,8 +20,8 @@ const initialState = {
   eraseModeOn: false,
   voiceModeOn: false,
   drawModeOn: false,
-  chosenBrush: 'defaultLine',
-  chosenBodyPart: 'rightHand',
+  chosenBrush: 'circleLine',
+  chosenBodyPart: 'nose',
   size: 'small'
 }
 

--- a/client/utils/camera.js
+++ b/client/utils/camera.js
@@ -11,6 +11,8 @@ import {
 import {Path} from 'paper'
 
 import store, {toggleErase, toggleDraw} from '../store'
+import {array} from '@tensorflow/tfjs-data'
+import {arrayOf} from 'prop-types'
 //will be moved to UI
 let minPartConfidence = 0.75
 
@@ -97,8 +99,14 @@ const guiState = {
 
 let handRight
 let handLeft
-let eraseSwitchedOff = false
+let arrayOfShapes = []
+let colorModeToggled = false
+let brushModeToggled = false
 
+let colorAtStart = store.getState().color.color
+let brushAtStart = store.getState().paintTools.chosenBrush
+
+let togglePoint
 function detectPoseInRealTime(video, net) {
   const canvas = document.getElementById('output')
   const ctx = canvas.getContext('2d')
@@ -225,10 +233,20 @@ function detectPoseInRealTime(video, net) {
             //if somebody is there, calculate drawing needs
             if (nose.score >= minPartConfidence) {
               //determine current drawing tool and its coordinates
-              let keypoint =
-                currentBodyPart === 'nose'
-                  ? nose
-                  : currentBodyPart === 'leftHand' ? handLeft : handRight
+              //I had to remove this ternary, as it was messing up the drawAnything func
+              // let keypoint =
+              //   currentBodyPart === 'nose'
+              //     ? nose
+              //     : currentBodyPart === 'leftHand' ? handLeft : handRight
+
+              let keypoint
+              if (currentBodyPart === 'nose') {
+                keypoint = nose
+              } else if (currentBodyPart === 'leftHand') {
+                keypoint = handLeft
+              } else {
+                keypoint = handRight
+              }
 
               //When the user is hovering near the toolbar, kick off selection funcs (utils/draw.js)
 
@@ -242,7 +260,6 @@ function detectPoseInRealTime(video, net) {
               //add to arrays for averaging over frames
               lastFewXCoords[currentPoseNum] = x
               lastFewYCoords[currentPoseNum] = y
-              console.log(lastFewXCoords)
 
               if (!lastFewXCoords.includes('null')) {
                 keypoint = smooth(lastFewXCoords, lastFewYCoords)
@@ -250,20 +267,55 @@ function detectPoseInRealTime(video, net) {
 
               drawTracker(keypoint, videoWidth, videoHeight, paintingPointerCtx)
 
+              arrayOfShapes.push(path)
+
+              //every time the color or brush is changed, we should start a new path of shapes.
+              if (store.getState().color.color !== colorAtStart) {
+                colorModeToggled = true
+                togglePoint = arrayOfShapes.length
+                colorAtStart = store.getState().color.color
+
+                arrayOfShapes = arrayOfShapes.slice(togglePoint - 2)
+                colorModeToggled = false
+              }
+              if (store.getState().paintTools.chosenBrush !== brushAtStart) {
+                brushModeToggled = true
+                togglePoint = arrayOfShapes.length
+                brushAtStart = store.getState().paintTools.chosenBrush
+
+                arrayOfShapes = arrayOfShapes.slice(togglePoint - 2)
+                brushModeToggled = false
+              }
+
               if (eraseModeValue === 'false') {
                 ctx.globalCompositeOperation = 'source-over'
-
-                const thisPath = drawAnything(keypoint, path)
+                const thisPath = drawAnything(
+                  keypoint,
+                  path,
+                  handLeft,
+                  handRight,
+                  nose
+                )
                 path = thisPath
               } else {
-                path.removeSegment(path.segments.length - 1)
+                //WHAT HAPPENS WHEN ERASE MODE IS ON
 
-                //this turns off both erase and draw mode once there are no more segments to remove
-                if (path.segments.length === 0) {
-                  path = null
-                  store.dispatch(toggleErase())
-                  if (store.getState().paintTools.drawModeOn === true) {
-                    store.dispatch(toggleDraw())
+                if (store.getState().paintTools.chosenBrush !== 'defaultLine') {
+                  for (let i = -1; i <= arrayOfShapes.length; i++) {
+                    if (arrayOfShapes[i]) {
+                      arrayOfShapes[i].removeSegment(0)
+                    }
+                  }
+                } else {
+                  path.removeSegment(path.segments.length - 1)
+
+                  //this turns off both erase and draw mode once there are no more segments to remove
+                  if (path.segments.length === 0) {
+                    path = null
+                    store.dispatch(toggleErase())
+                    if (store.getState().paintTools.drawModeOn === true) {
+                      store.dispatch(toggleDraw())
+                    }
                   }
                 }
               }
@@ -278,6 +330,7 @@ function detectPoseInRealTime(video, net) {
 
     if (store.getState().paintTools.drawModeOn === false) {
       path = null
+
       paintingPointerCtx.clearRect(0, 0, videoWidth, videoHeight)
       lastFewXCoords = Array(frames).fill('null')
       lastFewYCoords = Array(frames).fill('null')

--- a/client/utils/camera.js
+++ b/client/utils/camera.js
@@ -11,8 +11,6 @@ import {
 import {Path} from 'paper'
 
 import store, {toggleErase, toggleDraw} from '../store'
-import {array} from '@tensorflow/tfjs-data'
-import {arrayOf} from 'prop-types'
 //will be moved to UI
 let minPartConfidence = 0.75
 

--- a/client/utils/draw.js
+++ b/client/utils/draw.js
@@ -41,18 +41,6 @@ export function clearCanvas() {
   paper.project.clear()
 }
 
-// export function eraseTool(path) {
-//   console.log('you should be erasing')
-//   // myPath = new Path()
-//   path.removeSegment(0)
-//   // if (store.getState().paintTools.eraseModeOn === false) {
-//   // }
-//   // const canvas = document.getElementById('output')
-//   // const ctx = canvas.getContext('2d')
-//   // ctx.clearRect(0, 0, ctx.width, ctx.height)
-//   // paper.project.clear()
-// }
-
 export function saveCanvas() {
   const backgroundCanvas = document.getElementById('background')
   const bgCtx = backgroundCanvas.getContext('2d')
@@ -106,7 +94,7 @@ function setSize(size) {
 }
 
 /*eslint-disable*/
-export function drawAnything(part, path) {
+export function drawAnything(part, path, left, right, nose) {
   const {chosenBrush, chosenBodyPart, size} = store.getState().paintTools
   const pixelWidth = setSize(size)
 
@@ -131,32 +119,44 @@ export function drawAnything(part, path) {
     case 'triangleLine':
       return drawTriangleLine(part, pixelWidth)
     case 'rectangle':
-      return drawRectangleShape(rightHand, leftHand, pixelWidth)
+      return drawRectangleShape(right, left, pixelWidth)
     case 'circleShape':
-      if (part === rightHand || part === leftHand) {
-        return drawCircleShape(nose, part, pixelWidth)
-      } else {
-        return drawCircleShape(nose, rightHand, pixelWidth)
-      }
+      return drawCircleShape(nose, right, pixelWidth)
     case 'ellipse':
-      if (part === rightHand || part === leftHand) {
-        return drawEllipseShape(nose, part, pixelWidth)
-      } else {
-        return drawEllipseShape(nose, rightHand, pixelWidth)
-      }
+      return drawEllipseShape(nose, right, pixelWidth)
     case 'triangleShape':
-      if (part === rightHand || part === leftHand) {
-        return drawTriangleShape(nose, part, pixelWidth)
-      } else {
-        return drawTriangleShape(nose, rightHand, pixelWidth)
-      }
+      return drawTriangleShape(nose, right, pixelWidth)
+    // case 'circleShape':
+    //   console.log(part)
+    //   if (part === rightHand || part === leftHand) {
+    //     return drawCircleShape(nose, part, pixelWidth)
+    //   } else {
+    //     return drawCircleShape(nose, rightHand, pixelWidth)
+    //   }
+    // case 'ellipse':
+    //   if (part === rightHand || part === leftHand) {
+    //     return drawEllipseShape(nose, part, pixelWidth)
+    //   } else {
+    //     return drawEllipseShape(nose, rightHand, pixelWidth)
+    //   }
+    // case 'triangleShape':
+    //   if (part === rightHand || part === leftHand) {
+    //     return drawTriangleShape(nose, part, pixelWidth)
+    //   } else {
+    //     return drawTriangleShape(nose, rightHand, pixelWidth)
+    //   }
+
     default:
       return drawLine(part, path, pixelWidth)
   }
 }
 /*eslint-enable*/
 let oldColor = store.getState().color.color
-let compare = oldColor
+let colorToCompare = oldColor
+
+let oldBrush = store.getState().paintTools.chosenBrush
+let brushToCompare = oldBrush
+
 //draw lines
 function drawLine(oneKeypoint, path, pixelWidth) {
   let color = getColor()
@@ -168,9 +168,13 @@ function drawLine(oneKeypoint, path, pixelWidth) {
     strokeCap: 'round'
   })
 
-  if (store.getState().color.color !== compare) {
+  if (
+    store.getState().color.color !== colorToCompare ||
+    store.getState().paintTools.chosenBrush !== brushToCompare
+  ) {
     path = null
-    compare = store.getState().color.color
+    colorToCompare = store.getState().color.color
+    brushToCompare = store.getState().paintTools.chosenBrush
   }
   if (!path) path = pathStyle
 
@@ -182,13 +186,30 @@ function drawLine(oneKeypoint, path, pixelWidth) {
 //draw circle as line
 export function drawCircleLine(oneKeypoint, pixelWidth) {
   let color = getColor()
-
-  const shape = new Path.Circle(
+  let shape = new Path.Circle(
     new Point(oneKeypoint.position.x, oneKeypoint.position.y),
     30
   )
+
   shape.strokeColor = new Color(color.red, color.green, color.blue)
   shape.strokeWidth = pixelWidth
+
+  if (
+    store.getState().color.color !== colorToCompare ||
+    store.getState().paintTools.chosenBrush !== brushToCompare
+  ) {
+    shape = null
+    colorToCompare = store.getState().color.color
+    brushToCompare = store.getState().paintTools.chosenBrush
+  }
+  if (!shape) {
+    shape = new Path.Circle(
+      new Point(oneKeypoint.position.x, oneKeypoint.position.y),
+      30
+    )
+    shape.strokeColor = new Color(color.red, color.green, color.blue)
+    shape.strokeWidth = pixelWidth
+  }
 
   return shape
 }
@@ -249,13 +270,32 @@ function drawEllipseShape(oneKeypoint, secondKeypoint, pixelWidth) {
 function drawTriangleLine(oneKeypoint, pixelWidth) {
   let color = getColor()
 
-  const triangle = new Path.RegularPolygon(
+  let triangle = new Path.RegularPolygon(
     new Point(oneKeypoint.position.x, oneKeypoint.position.y),
     3,
     30
   )
   triangle.strokeColor = new Color(color.red, color.green, color.blue)
   triangle.strokeWidth = pixelWidth
+
+  if (
+    store.getState().color.color !== colorToCompare ||
+    store.getState().paintTools.chosenBrush !== brushToCompare
+  ) {
+    triangle = null
+    colorToCompare = store.getState().color.color
+    brushToCompare = store.getState().paintTools.chosenBrush
+  }
+
+  if (!triangle) {
+    triangle = new Path.RegularPolygon(
+      new Point(oneKeypoint.position.x, oneKeypoint.position.y),
+      3,
+      30
+    )
+    triangle.strokeColor = new Color(color.red, color.green, color.blue)
+    triangle.strokeWidth = pixelWidth
+  }
 
   return triangle
 }


### PR DESCRIPTION
**FIX**
A few of the brushes were broken. There seemed to be a mix-up caused by the switch statement in the drawAnything function in draw.js **and/or** a ternary operator in camera.js (line 242). I commented the original code out, instead of deleting it outright... Just in case anybody wanted to give it a second glance for refactoring.

**FEATURE**
User can now erase/rewind any path (shape or line!) that they have created since the last color **or** tool change! I'm experiencing a strange bug where the very last path entry in the PREVIOUS path sticks around. Can't figure that one out >.<

Please play around with the erasing tool and let me know if anything can be improved upon. Due to our limited PaperJS erasing functionality, the closest we can get is deleting every NEW path. Unfortunately, we can't erase anything EARLIER than the last Path present... The user will have to clear canvas. Definitely not ideal, sorry. :(