### PR TITLE
fix: drawer logic: only one can be opened at once

### DIFF
--- a/client/store/expansionPanels.js
+++ b/client/store/expansionPanels.js
@@ -31,9 +31,15 @@ const expansionPanels = (state = initialState, action) => {
   let newState = {...state}
   switch (action.type) {
     case TOGGLE_BODYPART:
+      if (state.brush) {
+        newState.brush = false
+      }
       newState.bodyPart = !state.bodyPart
       return newState
     case TOGGLE_BRUSH:
+      if (state.bodyPart) {
+        newState.bodyPart = false
+      }
       newState.brush = !state.brush
       return newState
     case TOGGLE_COLORPICKER:


### PR DESCRIPTION
altered the redux store to ensure that only one drawer is opened at once