### PR TITLE
FIX: Camera now loads properly after landing page without refresh

### DIFF
--- a/client/components/cameraComponent.js
+++ b/client/components/cameraComponent.js
@@ -67,7 +67,6 @@ class CameraComponent extends Component {
   }
 
   componentDidMount() {
-    // require('../utils/camera')
     bindPage()
   }
   componentDidUpdate(prevProps) {

--- a/client/components/cameraComponent.js
+++ b/client/components/cameraComponent.js
@@ -11,6 +11,7 @@ import store from '../store'
 import {takeSnapshot, lightboxOff} from '../store/lightbox'
 import {connect} from 'react-redux'
 import {Switch, withStyles, FormControlLabel} from '@material-ui/core'
+import {bindPage} from '../utils/camera'
 
 const styles = theme => ({
   colorBar: {},
@@ -66,7 +67,8 @@ class CameraComponent extends Component {
   }
 
   componentDidMount() {
-    require('../utils/camera')
+    // require('../utils/camera')
+    bindPage()
   }
   componentDidUpdate(prevProps) {
     return prevProps.showLightbox !== this.props.showLightbox

--- a/client/utils/camera.js
+++ b/client/utils/camera.js
@@ -387,6 +387,3 @@ export async function bindPage() {
 
   setTimeout(() => detectPoseInRealTime(video, net, model, mobileNet), 1000)
 }
-
-// kick off the demo
-// bindPage()

--- a/client/utils/camera.js
+++ b/client/utils/camera.js
@@ -389,4 +389,4 @@ export async function bindPage() {
 }
 
 // kick off the demo
-bindPage()
+// bindPage()


### PR DESCRIPTION
It was a simple fix - we were requiring in our util file, camera.js, which kicks off the bindPage function... regardless of which components mounted. 

So, instead, I exported the bindPage function, did NOT call it at the end of our util/camera.js file, and instead called it in the componentDidMount of our Camera component. ;)